### PR TITLE
Extending DTOs with finished players and next players

### DIFF
--- a/src/main/java/hu/bme/aut/ladder/controller/BaseGameController.java
+++ b/src/main/java/hu/bme/aut/ladder/controller/BaseGameController.java
@@ -121,7 +121,15 @@ public abstract class BaseGameController {
             playerDTO.setPosition(player.getPosition());
             playerDTO.setName(player.getName());
             playerDTO.setIsMe(player.equals(user.getPlayer()));
+            playerDTO.setIsFinished(player.isFinishedPlaying());
+            playerDTO.setFinishedAtPlace(player.getFinishedAtPlace());
+            playerDTO.setType(player.getType().name());
             playerDTOList.add(playerDTO);
+            
+            // Is this the next player (if there is any)
+            if(board.getNextPlayer() != null && player.getPlayerId().equals(board.getNextPlayer().getPlayerId())){
+                dto.setNextPlayer(playerDTO);
+            }            
         }
         dto.setPlayers(playerDTOList);
         

--- a/src/main/java/hu/bme/aut/ladder/controller/dto/BoardDTO.java
+++ b/src/main/java/hu/bme/aut/ladder/controller/dto/BoardDTO.java
@@ -28,6 +28,11 @@ public class BoardDTO {
     private List<PlayerDTO> players;
     
     /**
+     * Next player who should take an action
+     */
+    private PlayerDTO nextPlayer;
+    
+    /**
      * State changes
      */
     private List<StateChangeDTO> stateChanges;
@@ -70,5 +75,13 @@ public class BoardDTO {
 
     public void setStateChanges(List<StateChangeDTO> stateChanges) {
         this.stateChanges = stateChanges;
+    }
+
+    public PlayerDTO getNextPlayer() {
+        return nextPlayer;
+    }
+
+    public void setNextPlayer(PlayerDTO nextPlayer) {
+        this.nextPlayer = nextPlayer;
     }
 }

--- a/src/main/java/hu/bme/aut/ladder/controller/dto/PlayerDTO.java
+++ b/src/main/java/hu/bme/aut/ladder/controller/dto/PlayerDTO.java
@@ -31,6 +31,16 @@ public class PlayerDTO {
      * Can be either <i>HUMAN</i> or <i>ROBOT</i>
      */
     private String type;
+    
+    /**
+     * Value indicating that this player has finished playing
+     */
+    private boolean isFinished;
+    
+    /**
+     * Value indicating the place (1st, 2nd, etc.) this player finished on if {@link #isFinished} is <i>true</i>
+     */
+    private int finishedAtPlace;
 
     public int getPosition() {
         return position;
@@ -71,4 +81,20 @@ public class PlayerDTO {
     public void setType(String type) {
         this.type = type;
     }   
+
+    public boolean isIsFinished() {
+        return isFinished;
+    }
+
+    public void setIsFinished(boolean isFinished) {
+        this.isFinished = isFinished;
+    }
+
+    public int getFinishedAtPlace() {
+        return finishedAtPlace;
+    }
+
+    public void setFinishedAtPlace(int finishedAtPlace) {
+        this.finishedAtPlace = finishedAtPlace;
+    }
 }

--- a/src/main/java/hu/bme/aut/ladder/data/entity/GameEntity.java
+++ b/src/main/java/hu/bme/aut/ladder/data/entity/GameEntity.java
@@ -73,7 +73,7 @@ public class GameEntity {
      * State of the game
      */
     public static enum GameState {
-        INITIALIZED, BOARD_STARTED, FINISHED
+        INITIALIZED, BOARD_STARTED
     }
 
     public Long getGameId() {

--- a/src/main/java/hu/bme/aut/ladder/data/entity/PlayerEntity.java
+++ b/src/main/java/hu/bme/aut/ladder/data/entity/PlayerEntity.java
@@ -53,6 +53,18 @@ public class PlayerEntity {
      */
     @Column
     private String name;
+    
+    /**
+     * Value indicating that user is done playing the game, reached the last field on the board
+     */
+    @Column
+    private boolean finishedPlaying = false;
+    
+    /**
+     * Place at which this player finished
+     */
+    @Column
+    private int finishedAtPlace = 0;
 
     public Long getPlayerId() {
         return playerId;
@@ -92,6 +104,22 @@ public class PlayerEntity {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public boolean isFinishedPlaying() {
+        return finishedPlaying;
+    }
+
+    public void setFinishedPlaying(boolean finishedPlaying) {
+        this.finishedPlaying = finishedPlaying;
+    }
+
+    public int getFinishedAtPlace() {
+        return finishedAtPlace;
+    }
+
+    public void setFinishedAtPlace(int finishedAtPlace) {
+        this.finishedAtPlace = finishedAtPlace;
     }
     
     public enum Color {

--- a/src/main/java/hu/bme/aut/ladder/strategy/impl/SimpleBoardStrategyImpl.java
+++ b/src/main/java/hu/bme/aut/ladder/strategy/impl/SimpleBoardStrategyImpl.java
@@ -31,7 +31,6 @@ public class SimpleBoardStrategyImpl implements BoardStrategy {
      */
     private Dice dice = new SimpleDiceImpl();
     
-    
     /**
      * {@inheritDoc}
      */
@@ -56,6 +55,11 @@ public class SimpleBoardStrategyImpl implements BoardStrategy {
         // Only rolling is allowed in the simple version
         if(!"ROLL".equalsIgnoreCase(action)){
             throw new BoardActionNotPermitted("Only ROLL is permitted by " + this.getClass().getSimpleName());
+        }
+        
+        // If player has already finished playing then this is not allowed
+        if(player.isFinishedPlaying()){
+            throw new BoardActionNotPermitted("Player has already finished playing: " + player.getName());
         }
         
         // Move the next player and any number of robot players
@@ -88,8 +92,30 @@ public class SimpleBoardStrategyImpl implements BoardStrategy {
             }
         }
         
-        // Set next player to (i+1) mod NumberOfPlayers
-        board.setNextPlayer(board.getPlayers().get((i+1) % board.getPlayers().size()));
+        // Did this player finish?
+        if(player.getPosition() >= board.getBoardSize()-1){
+            player.setFinishedPlaying(true);
+            
+            // How many others have finished already (including me!)
+            int count = 0;
+            for(PlayerEntity playersInGame : board.getPlayers()){
+                if(playersInGame.isFinishedPlaying()){
+                    ++count;
+                }
+            }
+            
+            player.setFinishedAtPlace(count);            
+        }
+        
+        // Set next player to (i+1) mod NumberOfPlayers, but skip as long
+        // as the given player has already finished playing!
+        for(int j = 1; j < board.getPlayers().size(); j++){
+            final PlayerEntity nextPlayer = board.getPlayers().get((i+j) % board.getPlayers().size());
+            if(!nextPlayer.isFinishedPlaying()){
+                board.setNextPlayer(nextPlayer);
+                break;
+            }
+        }
     }
     
     /**

--- a/src/test/java/hu/bme/aut/ladder/strategy/impl/SimpleBoardStrategyImplTest.java
+++ b/src/test/java/hu/bme/aut/ladder/strategy/impl/SimpleBoardStrategyImplTest.java
@@ -220,6 +220,58 @@ public class SimpleBoardStrategyImplTest {
     }
     
     /**
+     * Test that when a player reaches the last (size-1) field they are considered
+     * finished.
+     * 
+     * @throws BoardActionNotPermitted 
+     */
+    @Test
+    public void thatPlayerIsFinishedOnceReachesLastField() throws BoardActionNotPermitted {
+        
+         // Arrange
+        BoardEntity board = mockBoard(1);
+        final int diceRolled = 5;
+        target.setDice(diceWhichRollsTheSame(diceRolled));
+        
+        // Set player's position
+        int playerStartsFrom = board.getBoardSize() - diceRolled;
+        board.getPlayers().get(0).setPosition(playerStartsFrom);
+                
+        // Act
+        target.executeAction(board, board.getPlayers().get(0), "ROLL");
+     
+        // Assert
+        final PlayerEntity player = board.getPlayers().get(0);
+        
+        assertEquals("Player should be at the last position", board.getBoardSize() - 1, player.getPosition());
+        assertEquals("This player should have finished", true, player.isFinishedPlaying());
+        assertEquals("This player should be the winner", 1, player.getFinishedAtPlace());
+    }
+    
+    /**
+     * Test that when a player has finished playing, they can't roll any more
+     * 
+     * @throws BoardActionNotPermitted 
+     */
+    @Test(expected = BoardActionNotPermitted.class)
+    public void thatPlayerWhoFinishedCantRoll() throws BoardActionNotPermitted {
+        
+         // Arrange
+        BoardEntity board = mockBoard(1);
+        final int diceRolled = 5;
+        target.setDice(diceWhichRollsTheSame(diceRolled));
+        
+        // Set player's position and that he has finished playing
+        int playerStartsFrom = board.getBoardSize() - diceRolled;
+        board.getPlayers().get(0).setPosition(playerStartsFrom);
+        board.getPlayers().get(0).setFinishedPlaying(true);
+        board.getPlayers().get(0).setFinishedAtPlace(1);
+                
+        // Act
+        target.executeAction(board, board.getPlayers().get(0), "ROLL");
+    }
+    
+    /**
      * Creates a simple board
      * 
      * @param numberOfPlayers


### PR DESCRIPTION
Új mezők a player és a board DTOk-be, amik jelzik a játékosok állapotát a játékon belül.

Plusz  a finished állapotra nincsen szükség igazából, illetve a player JSON type mezőjét elfelejtettem eddig tölteni, mondjuk a UI nem használja, de használhatná.
