### PR TITLE
Earthquake sequenceNumber fix

### DIFF
--- a/src/main/java/hu/bme/aut/ladder/strategy/impl/EarthquakeBoardStrategyImpl.java
+++ b/src/main/java/hu/bme/aut/ladder/strategy/impl/EarthquakeBoardStrategyImpl.java
@@ -3,8 +3,11 @@ package hu.bme.aut.ladder.strategy.impl;
 import hu.bme.aut.ladder.data.entity.AbilityEntity;
 import hu.bme.aut.ladder.data.entity.BoardEntity;
 import hu.bme.aut.ladder.data.entity.PlayerEntity;
+import hu.bme.aut.ladder.data.entity.StateChangeEntity;
 import hu.bme.aut.ladder.strategy.exception.BoardActionNotPermitted;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -67,6 +70,17 @@ public class EarthquakeBoardStrategyImpl extends BaseRollingBoardStrategy {
             
             // Reduce the number of earthquakes for this player
             earthquake.setUsesLeft(earthquake.getUsesLeft() - 1);
+            
+            // Earthquakes may screw up the ordering of the state change entities entities,
+            // let's fix that here
+            Collections.sort(board.getStateChanges(), new Comparator<StateChangeEntity>(){
+                @Override
+                public int compare(StateChangeEntity o1, StateChangeEntity o2) {
+                    return o1.getSequenceNumber() - o2.getSequenceNumber();
+                }
+                
+            });
+            
         } else {
             throw new BoardActionNotPermitted("Only ROLL and EARTHQUAKE is permitted by " + this.getClass().getSimpleName());
         }


### PR DESCRIPTION
Szóval a para az, hogy a sequenceNumber szerinti rendezést akkor csinálja meg a JPA amikor az adatbázisból kiveszi a elemeket. Ha egy tranzakción belül írjuk és olvassuk is a listát akkor azt adja vissza ahogy mi elmentettük és nem járja meg az utat az adatbázisig újra. 

Ez egyedül itt okoz problémát szóval ez egy kicsit hotfix...
