### PR TITLE
gameEnd bug

### DIFF
--- a/src/main/webapp/js/game.js
+++ b/src/main/webapp/js/game.js
@@ -759,15 +759,18 @@ function processAnimations() {
 	else {
 		processing = false;
 		if(boardData.nextPlayer == null || boardData.nextPlayer.color === playerMe().color) {
-			$("#roll_button").removeClass("disabled");
-			
 			if(!turnMessageShown) {
 				showText("It's your turn!");
 				turnMessageShown = true;
-				startTimer(function() {$('#roll_button').click();}, {}, TIME_FORUSERACTION * 1000);
+				if(!playerMe().isFinished) {
+					startTimer(function() {$('#roll_button').click();}, {}, TIME_FORUSERACTION * 1000);
+				}
 			}
-			if(playerMe().abilityUsesLeft.EARTHQUAKE > 0) {
-				$("#earthquake_button").removeClass("disabled");
+			if(!playerMe().isFinished) {
+				$("#roll_button").removeClass("disabled");
+				if(playerMe().abilityUsesLeft.EARTHQUAKE > 0) {
+					$("#earthquake_button").removeClass("disabled");
+				}
 			}
 		}
 		


### PR DESCRIPTION
ha a robotok után ért be a játékos, akkor a nextPlayer ő maradt még azután is, ha beért, ezért az autoroll, és a roll actionnel lehetett küldeni kockadobást a szerver felé, amire a szerver internal errorral válaszolt.
Fix: ha a játékos beért, akkor nincs autoroll, és nem dobhat a kockával
